### PR TITLE
fix: resolve comment badge showing wrong count in table list view

### DIFF
--- a/src/Filament/Actions/CommentsAction.php
+++ b/src/Filament/Actions/CommentsAction.php
@@ -23,9 +23,7 @@ class CommentsAction extends Action
                     'record' => $this->getRecord(),
                 ]);
             })
-            ->badge(function (): ?int {
-                $record = $this->getRecord();
-
+            ->badge(function ($record): ?int {
                 if (! $record) {
                     return null;
                 }


### PR DESCRIPTION
The badge closure was using $this->getRecord() where $this was bound to the prototype action, not the per-row clone. This caused badges to show nothing on initial load and the same count on all rows after a modal was opened. Fixes #14.