### PR TITLE
feat: add configurable user name resolution for mentions

### DIFF
--- a/config/comments.php
+++ b/config/comments.php
@@ -53,6 +53,21 @@ return [
     'mentions' => [
         'resolver' => DefaultMentionResolver::class,
         'max_results' => 5,
+
+        /*
+         | The database column used to display and resolve user names in mentions.
+         | Change this if your users table stores names in a different column (e.g. 'username', 'full_name').
+         | For computed names (firstname + lastname), leave this as 'name' and use
+         | CommentsConfig::resolveUserNameUsing() in your AppServiceProvider instead.
+         */
+        'name_column' => 'name',
+
+        /*
+         | Columns to search when looking up users during @mention autocomplete.
+         | Useful when the display name is composed of multiple columns (e.g. ['firstname', 'lastname']).
+         | Defaults to ['name'] (or whatever name_column is set to) when not specified.
+         */
+        // 'search_columns' => ['firstname', 'lastname'],
     ],
 
     'editor' => [

--- a/docs/content/2.essentials/3.mentions.md
+++ b/docs/content/2.essentials/3.mentions.md
@@ -18,11 +18,43 @@ Type `@` in the comment editor to trigger user autocomplete. Select a user to in
 
 ## Default Resolver
 
-The `DefaultMentionResolver` searches the commenter model by name:
+The `DefaultMentionResolver` searches the commenter model using the configured `name_column` (defaults to `name`):
 
 ```php
 // Searches: User::where('name', 'like', "{$query}%")
 // Limited to: config('comments.mentions.max_results') results
+```
+
+### Custom Name Column
+
+If your users table uses a different column for names, set `name_column` in the config:
+
+```php
+// config/comments.php
+'mentions' => [
+    'name_column' => 'username', // or 'full_name', etc.
+],
+```
+
+### Multi-Column Search
+
+If the display name is composed of multiple columns (e.g. `firstname` + `lastname`), configure `search_columns`:
+
+```php
+// config/comments.php
+'mentions' => [
+    'search_columns' => ['firstname', 'lastname'],
+],
+```
+
+Then register a name resolver in your `AppServiceProvider::boot()`:
+
+```php
+use Relaticle\Comments\CommentsConfig;
+
+CommentsConfig::resolveUserNameUsing(
+    fn ($user) => $user->firstname . ' ' . $user->lastname
+);
 ```
 
 ## Custom Mention Resolver
@@ -72,3 +104,5 @@ Register it in your config:
 |-----|---------|-------------|
 | `mentions.resolver` | `DefaultMentionResolver::class` | User search implementation |
 | `mentions.max_results` | `5` | Maximum autocomplete results |
+| `mentions.name_column` | `'name'` | DB column used for display and resolution |
+| `mentions.search_columns` | `[name_column]` | DB columns searched during autocomplete |

--- a/src/CommentsConfig.php
+++ b/src/CommentsConfig.php
@@ -13,6 +13,8 @@ class CommentsConfig
 {
     protected static ?Closure $resolveAuthenticatedUser = null;
 
+    protected static ?Closure $resolveUserName = null;
+
     public static function getCommentModel(): string
     {
         return config('comments.models.comment', Comment::class);
@@ -79,6 +81,37 @@ class CommentsConfig
     public static function getMentionMaxResults(): int
     {
         return (int) config('comments.mentions.max_results', 5);
+    }
+
+    public static function getMentionNameColumn(): string
+    {
+        return (string) config('comments.mentions.name_column', 'name');
+    }
+
+    /** @return array<int, string> */
+    public static function getMentionSearchColumns(): array
+    {
+        $columns = config('comments.mentions.search_columns');
+
+        if (is_array($columns) && count($columns) > 0) {
+            return $columns;
+        }
+
+        return [static::getMentionNameColumn()];
+    }
+
+    public static function resolveUserNameUsing(Closure $callback): void
+    {
+        static::$resolveUserName = $callback;
+    }
+
+    public static function getUserName(object $user): string
+    {
+        if (static::$resolveUserName) {
+            return (string) call_user_func(static::$resolveUserName, $user);
+        }
+
+        return (string) ($user->{static::getMentionNameColumn()} ?? '');
     }
 
     /** @return array<string, string> */
@@ -209,15 +242,25 @@ class CommentsConfig
     public static function makeMentionProvider(): MentionProvider
     {
         return MentionProvider::make('@')
-            ->getSearchResultsUsing(fn (string $search): array => static::getCommenterModel()::query()
-                ->where('name', 'like', "%{$search}%")
-                ->orderBy('name')
-                ->limit(static::getMentionMaxResults())
-                ->pluck('name', 'id')
-                ->all())
+            ->getSearchResultsUsing(function (string $search): array {
+                $query = static::getCommenterModel()::query();
+
+                foreach (static::getMentionSearchColumns() as $index => $column) {
+                    $method = $index === 0 ? 'where' : 'orWhere';
+                    $query->{$method}($column, 'like', "%{$search}%");
+                }
+
+                return $query
+                    ->orderBy(static::getMentionNameColumn())
+                    ->limit(static::getMentionMaxResults())
+                    ->get()
+                    ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
+                    ->all();
+            })
             ->getLabelsUsing(fn (array $ids): array => static::getCommenterModel()::query()
                 ->whereIn('id', $ids)
-                ->pluck('name', 'id')
+                ->get()
+                ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
                 ->all());
     }
 }

--- a/src/Mentions/DefaultMentionResolver.php
+++ b/src/Mentions/DefaultMentionResolver.php
@@ -13,9 +13,14 @@ class DefaultMentionResolver implements MentionResolver
     public function search(string $query): Collection
     {
         $model = CommentsConfig::getCommenterModel();
+        $builder = $model::query();
 
-        return $model::query()
-            ->where('name', 'like', "{$query}%")
+        foreach (CommentsConfig::getMentionSearchColumns() as $index => $column) {
+            $method = $index === 0 ? 'where' : 'orWhere';
+            $builder->{$method}($column, 'like', "{$query}%");
+        }
+
+        return $builder
             ->limit(CommentsConfig::getMentionMaxResults())
             ->get();
     }
@@ -24,9 +29,10 @@ class DefaultMentionResolver implements MentionResolver
     public function resolveByNames(array $names): Collection
     {
         $model = CommentsConfig::getCommenterModel();
+        $nameColumn = CommentsConfig::getMentionNameColumn();
 
         return $model::query()
-            ->whereIn('name', $names)
+            ->whereIn($nameColumn, $names)
             ->get();
     }
 }


### PR DESCRIPTION
Fixes the crash when User models use computed name attributes instead of a real `name` DB column.

- Add `name_column` config key to specify which column stores display names
- Add `search_columns` config key to search across multiple columns (e.g. firstname + lastname)
- Add `CommentsConfig::resolveUserNameUsing()` callback for fully custom name resolution
- Update DefaultMentionResolver and makeMentionProvider to use new config
- No breaking changes — defaults preserve existing behavior