### PR TITLE
fix: translation follow-ups (JS-safe, plural, missing keys) [1.x]

### DIFF
--- a/resources/lang/en/comments.php
+++ b/resources/lang/en/comments.php
@@ -39,7 +39,7 @@ return [
         'thinking' => 'Thinking',
         'sad' => 'Sad',
         'reacted_by' => ':names reacted with :reaction',
-        'and_others' => 'and :count others',
+        'and_others' => '{1} and one other|[2,*] and :count others',
         'like' => 'Like',
         'add_reaction' => 'Add reaction',
     ],

--- a/resources/views/livewire/comment-item.blade.php
+++ b/resources/views/livewire/comment-item.blade.php
@@ -140,7 +140,7 @@
         @if ($isReplying)
             <div class="mt-3"
                 x-data="{ uploadError: null }"
-                x-on:livewire-upload-error.window="uploadError = '{{ __('comments::comments.attachments.upload_failed') }}'"
+                x-on:livewire-upload-error.window="uploadError = {{ Illuminate\Support\Js::from(__('comments::comments.attachments.upload_failed')) }}"
                 x-on:livewire-upload-start.window="uploadError = null"
             >
                 {{ $this->replyForm }}

--- a/resources/views/livewire/comments.blade.php
+++ b/resources/views/livewire/comments.blade.php
@@ -3,14 +3,14 @@
         wire:poll.{{ \Relaticle\Comments\CommentsConfig::getPollingInterval() }}
     @endif
     x-data="{ uploadError: null }"
-    x-on:livewire-upload-error.window="uploadError = '{{ __('comments::comments.attachments.upload_failed') }}'"
+    x-on:livewire-upload-error.window="uploadError = {{ Illuminate\Support\Js::from(__('comments::comments.attachments.upload_failed')) }}"
     x-on:livewire-upload-start.window="uploadError = null"
 >
     <div class="comments-body space-y-4">
     {{-- Sort toggle --}}
     <div class="flex items-center justify-between">
         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">
-            {{ __('comments::comments.title') }} ({{ $this->allCommentsCount }})
+            {{ __('comments::comments.count', ['count' => $this->allCommentsCount]) }}
         </h3>
         @auth
             <div class="flex items-center gap-3">

--- a/resources/views/livewire/reactions.blade.php
+++ b/resources/views/livewire/reactions.blade.php
@@ -4,7 +4,7 @@
         <button
             wire:click="toggleReaction('{{ $summary['reaction'] }}')"
             type="button"
-            title="{{ implode(', ', $summary['names']) }}{{ $summary['total_reactors'] > 3 ? ' '.__('comments::comments.reactions.and_others', ['count' => $summary['total_reactors'] - 3]) : '' }}"
+            title="{{ implode(', ', $summary['names']) }}{{ $summary['total_reactors'] > 3 ? ' '.trans_choice('comments::comments.reactions.and_others', $summary['total_reactors'] - 3, ['count' => $summary['total_reactors'] - 3]) : '' }}"
             class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition
                 {{ $summary['reacted_by_user']
                     ? 'border-primary-300 bg-primary-50 text-primary-700 dark:border-primary-600 dark:bg-primary-900/30 dark:text-primary-300'
@@ -45,7 +45,7 @@
                 @foreach (\Relaticle\Comments\CommentsConfig::getReactionEmojiSet() as $key => $emoji)
                     <button wire:click="toggleReaction('{{ $key }}')" type="button"
                             class="rounded p-1 text-base hover:bg-gray-100 dark:hover:bg-gray-700"
-                            title="{{ str_replace('_', ' ', $key) }}">
+                            title="{{ __('comments::comments.reactions.'.$key) }}">
                         {{ $emoji }}
                     </button>
                 @endforeach

--- a/src/Concerns/CanComment.php
+++ b/src/Concerns/CanComment.php
@@ -13,7 +13,7 @@ trait CanComment
             return $this->getFilamentName();
         }
 
-        return $this->name ?? 'Unknown';
+        return $this->name ?? __('comments::comments.unknown_user');
     }
 
     public function getCommentAvatarUrl(): ?string

--- a/tests/Feature/TranslationCoherenceTest.php
+++ b/tests/Feature/TranslationCoherenceTest.php
@@ -38,7 +38,7 @@ beforeEach(function (): void {
         'comments.attachments.upload_failed' => 'OVERRIDDEN_UPLOAD_FAILED',
         'comments.reactions.like' => 'OVERRIDDEN_LIKE',
         'comments.reactions.add_reaction' => 'OVERRIDDEN_ADD_REACTION',
-        'comments.reactions.and_others' => 'OVERRIDDEN_AND_:count_OTHERS',
+        'comments.reactions.and_others' => '{1} OVERRIDDEN_AND_ONE_OTHER|[2,*] OVERRIDDEN_AND_:count_OTHERS',
         'comments.notifications.reply_subject' => 'OVERRIDDEN_REPLY_SUBJECT',
         'comments.notifications.reply_body' => 'OVERRIDDEN_REPLY_BODY_BY_:name',
         'comments.notifications.mention_subject' => 'OVERRIDDEN_MENTION_SUBJECT',
@@ -74,7 +74,6 @@ it('uses the comments translation namespace for hardcoded blade strings', functi
     $this->actingAs($user);
 
     Livewire::test(Comments::class, ['model' => $post])
-        ->assertSee('OVERRIDDEN_TITLE')
         ->assertSee('OVERRIDDEN_SUBSCRIBE_SHORT')
         ->assertSee('OVERRIDDEN_SUBMIT')
         ->assertSee('OVERRIDDEN_ATTACH');
@@ -160,4 +159,85 @@ it('uses the comments translation namespace for the reaction summary "and X more
     $html = Livewire::test(Reactions::class, ['comment' => $comment->fresh()])->html();
 
     expect($html)->toContain('OVERRIDDEN_AND_2_OTHERS');
+});
+
+it('encodes upload-failed translation safely for Alpine JS context', function (): void {
+    Lang::addLines([
+        'comments.attachments.upload_failed' => "Quote'and \\backslash and\nnewline",
+    ], 'en', 'comments');
+
+    $post = Post::factory()->create();
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $html = Livewire::test(Comments::class, ['model' => $post])->html();
+
+    // Js::from emits a JSON-encoded string with escaped quotes/backslashes/newlines.
+    // The raw apostrophe must NOT appear unescaped inside the x-on attribute.
+    expect($html)->toContain('uploadError = ');
+    expect($html)->not->toContain("uploadError = 'Quote'");
+});
+
+it('localizes emoji-picker tooltip via reactions namespace', function (): void {
+    Lang::addLines([
+        'comments.reactions.thumbs_up' => 'OVERRIDDEN_THUMBS_UP_TOOLTIP',
+    ], 'en', 'comments');
+
+    $post = Post::factory()->create();
+    $user = User::factory()->create();
+    $this->actingAs($user);
+    $comment = $post->comments()->create([
+        'body' => 'hi',
+        'commenter_id' => $user->getKey(),
+        'commenter_type' => $user->getMorphClass(),
+    ]);
+
+    $html = Livewire::test(Reactions::class, ['comment' => $comment->fresh()])->html();
+
+    expect($html)->toContain('title="OVERRIDDEN_THUMBS_UP_TOOLTIP"');
+});
+
+it('uses comments::comments.count for the section header', function (): void {
+    Lang::addLines([
+        'comments.count' => 'OVERRIDDEN_COUNT_HEADER (:count)',
+    ], 'en', 'comments');
+
+    $post = Post::factory()->create();
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test(Comments::class, ['model' => $post])
+        ->assertSee('OVERRIDDEN_COUNT_HEADER (0)');
+});
+
+it('renders singular form when exactly one extra reactor', function (): void {
+    // Restore the package's real plural string for this test (override the beforeEach mock).
+    Lang::addLines([
+        'comments.reactions.and_others' => '{1} and one other|[2,*] and :count others',
+    ], 'en', 'comments');
+
+    $post = Post::factory()->create();
+    $author = User::factory()->create(['name' => 'Author']);
+    $this->actingAs($author);
+
+    $comment = $post->comments()->create([
+        'body' => 'hi',
+        'commenter_id' => $author->getKey(),
+        'commenter_type' => $author->getMorphClass(),
+    ]);
+
+    // 4 reactors total → 3 names + 1 other (singular)
+    foreach (range(1, 4) as $i) {
+        $u = User::factory()->create(['name' => "User{$i}"]);
+        $comment->reactions()->create([
+            'commenter_id' => $u->getKey(),
+            'commenter_type' => $u->getMorphClass(),
+            'reaction' => 'thumbs_up',
+        ]);
+    }
+
+    $html = Livewire::test(Reactions::class, ['comment' => $comment->fresh()])->html();
+
+    expect($html)->toContain('and one other');
+    expect($html)->not->toContain('and 1 others');
 });


### PR DESCRIPTION
## Summary

Follow-up to #22 (v1.0.1). Addresses Copilot review comments and 3 additional findings from a deeper audit. Targets v1.0.2.

## Findings fixed

1. **JS injection risk in Alpine handlers** — \`views/livewire/comments.blade.php:6\` and \`comment-item.blade.php:143\` interpolated translations into single-quoted JS. A translation containing \`'\`, \`\\\`, or \`\\n\` would break the page. Now uses \`Illuminate\\Support\\Js::from(...)\` for safe encoding.
2. **Emoji-picker tooltip rendered raw English** — \`reactions.blade.php:48\` used \`str_replace('_', ' ', \$key)\` to derive a tooltip from the data key. Now reads \`comments::comments.reactions.<key>\`, wiring up the previously-orphaned \`thumbs_up/heart/celebrate/laugh/thinking/sad\` lang entries.
3. **'Unknown' commenter fallback bypassed translation** — \`Concerns/CanComment.php\` returned the literal string \`'Unknown'\` when a commenter model exposed no name. Now uses \`comments::comments.unknown_user\`.
4. **Plural bug 'and 1 others'** — reactor-summary tooltip rendered "and 1 others" when exactly one extra reactor existed. \`reactions.and_others\` is now a pluralized string \`{1} and one other|[2,*] and :count others\` consumed via \`trans_choice\`.
5. **Section header used composite literal instead of \`count\` key** — \`comments.blade.php:13\` interpolated \`title\` + bare parens. Now uses \`comments::comments.count\` (\`'Comments (:count)'\`), letting translators control parenthesis placement (RTL/CJK).

## Tests

- 4 new regression cases covering: Alpine JS-safe encoding, emoji tooltip translation, count header translation, plural singular/plural rendering.
- All 12 cases in \`TranslationCoherenceTest\` pass; full suite green minus 2 pre-existing badge failures.

Closes follow-up to #21.