### PR TITLE
fix: migration parse error, mention search, notifications, and mention toggle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,17 @@ jobs:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
         laravel: [12.*]
+        filament: [4, 5]
         stability: [prefer-stable]
+        exclude:
+          # Filament 5 pulls Livewire 4 / pest-plugin-livewire 4, which need PHP 8.3+
+          - php: 8.2
+            filament: 5
         include:
           - laravel: 12.*
             testbench: 10.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -41,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:^${{ matrix.filament }}.0" "filament/notifications:^${{ matrix.filament }}.0" "filament/support:^${{ matrix.filament }}.0" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/config/comments.php
+++ b/config/comments.php
@@ -51,6 +51,12 @@ return [
     ],
 
     'mentions' => [
+        /*
+         | Enable @mention autocomplete in the comment editor and mention
+         | notifications. Set to false to turn the feature off entirely.
+         */
+        'enabled' => true,
+
         'resolver' => DefaultMentionResolver::class,
         'max_results' => 5,
 

--- a/database/migrations/create_comment_attachments_table.php.stub
+++ b/database/migrations/create_comment_attachments_table.php.stub
@@ -12,11 +12,11 @@ return new class extends Migration
             $table->id();
             if (config('comments.multi_tenancy.enabled', false)) {
                 $tenantColumn = config('comments.multi_tenancy.tenant_column', 'tenant_id');
-                match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
+                (match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
                     'uuid'   => $table->uuid($tenantColumn),
                     'string' => $table->string($tenantColumn),
                     default  => $table->unsignedBigInteger($tenantColumn),
-                }->nullable()->index();
+                })->nullable()->index();
             }
             $table->foreignId('comment_id')
                 ->constrained(config('comments.table_names.comments', 'comments'))

--- a/database/migrations/create_comment_mentions_table.php.stub
+++ b/database/migrations/create_comment_mentions_table.php.stub
@@ -12,11 +12,11 @@ return new class extends Migration
             $table->id();
             if (config('comments.multi_tenancy.enabled', false)) {
                 $tenantColumn = config('comments.multi_tenancy.tenant_column', 'tenant_id');
-                match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
+                (match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
                     'uuid'   => $table->uuid($tenantColumn),
                     'string' => $table->string($tenantColumn),
                     default  => $table->unsignedBigInteger($tenantColumn),
-                }->nullable()->index();
+                })->nullable()->index();
             }
             $table->foreignId('comment_id')
                 ->constrained(config('comments.table_names.comments', 'comments'))

--- a/database/migrations/create_comment_mentions_table.php.stub
+++ b/database/migrations/create_comment_mentions_table.php.stub
@@ -24,7 +24,7 @@ return new class extends Migration
             $table->morphs('commenter');
             $table->timestamps();
 
-            $table->unique(['comment_id', 'commenter_id', 'commenter_type']);
+            $table->unique(['comment_id', 'commenter_id', 'commenter_type'], 'comment_mentions_unique');
         });
     }
 };

--- a/database/migrations/create_comment_reactions_table.php.stub
+++ b/database/migrations/create_comment_reactions_table.php.stub
@@ -12,11 +12,11 @@ return new class extends Migration
             $table->id();
             if (config('comments.multi_tenancy.enabled', false)) {
                 $tenantColumn = config('comments.multi_tenancy.tenant_column', 'tenant_id');
-                match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
+                (match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
                     'uuid'   => $table->uuid($tenantColumn),
                     'string' => $table->string($tenantColumn),
                     default  => $table->unsignedBigInteger($tenantColumn),
-                }->nullable()->index();
+                })->nullable()->index();
             }
             $table->foreignId('comment_id')
                 ->constrained(config('comments.table_names.comments', 'comments'))
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->string('reaction');
             $table->timestamps();
 
-            $table->unique(['comment_id', 'commenter_id', 'commenter_type', 'reaction']);
+            $table->unique(['comment_id', 'commenter_id', 'commenter_type', 'reaction'], 'comment_reactions_unique');
         });
     }
 };

--- a/database/migrations/create_comment_subscriptions_table.php.stub
+++ b/database/migrations/create_comment_subscriptions_table.php.stub
@@ -12,11 +12,11 @@ return new class extends Migration
             $table->id();
             if (config('comments.multi_tenancy.enabled', false)) {
                 $tenantColumn = config('comments.multi_tenancy.tenant_column', 'tenant_id');
-                match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
+                (match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
                     'uuid'   => $table->uuid($tenantColumn),
                     'string' => $table->string($tenantColumn),
                     default  => $table->unsignedBigInteger($tenantColumn),
-                }->nullable()->index();
+                })->nullable()->index();
             }
             $table->morphs('commentable');
             $table->morphs('commenter');

--- a/database/migrations/create_comments_table.php.stub
+++ b/database/migrations/create_comments_table.php.stub
@@ -12,11 +12,11 @@ return new class extends Migration
             $table->id();
             if (config('comments.multi_tenancy.enabled', false)) {
                 $tenantColumn = config('comments.multi_tenancy.tenant_column', 'tenant_id');
-                match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
+                (match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
                     'uuid'   => $table->uuid($tenantColumn),
                     'string' => $table->string($tenantColumn),
                     default  => $table->unsignedBigInteger($tenantColumn),
-                }->nullable()->index();
+                })->nullable()->index();
             }
             $table->morphs('commentable');
             $table->morphs('commenter');

--- a/docs/content/2.essentials/1.configuration.md
+++ b/docs/content/2.essentials/1.configuration.md
@@ -101,12 +101,15 @@ Customize the available emoji reactions. Keys are used as identifiers in the dat
 
 ```php
 'mentions' => [
+    'enabled' => true,
     'resolver' => \Relaticle\Comments\Mentions\DefaultMentionResolver::class,
     'max_results' => 5,
 ],
 ```
 
 The resolver handles searching for users during @mention autocomplete. See the [Mentions](/essentials/mentions) page for creating a custom resolver.
+
+Set `enabled` to `false` to turn off @mention autocomplete in the editor and mention notifications entirely.
 
 ## Pinning
 

--- a/src/CommentsConfig.php
+++ b/src/CommentsConfig.php
@@ -4,6 +4,7 @@ namespace Relaticle\Comments;
 
 use App\Models\User;
 use Closure;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\MentionProvider;
 use Illuminate\Support\Facades\Gate;
 use Relaticle\Comments\Mentions\DefaultMentionResolver;
@@ -79,6 +80,11 @@ class CommentsConfig
     public static function getMentionResolver(): string
     {
         return config('comments.mentions.resolver', DefaultMentionResolver::class);
+    }
+
+    public static function areMentionsEnabled(): bool
+    {
+        return (bool) config('comments.mentions.enabled', true);
     }
 
     public static function getMentionMaxResults(): int
@@ -288,7 +294,7 @@ class CommentsConfig
                 }
 
                 return $query
-                    ->orderBy(static::getMentionNameColumn())
+                    ->orderBy(static::getMentionSearchColumns()[0])
                     ->limit(static::getMentionMaxResults())
                     ->get()
                     ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
@@ -299,5 +305,14 @@ class CommentsConfig
                 ->get()
                 ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
                 ->all());
+    }
+
+    public static function applyMentionProvider(RichEditor $editor): RichEditor
+    {
+        if (! static::areMentionsEnabled()) {
+            return $editor;
+        }
+
+        return $editor->mentions([static::makeMentionProvider()]);
     }
 }

--- a/src/Livewire/CommentItem.php
+++ b/src/Livewire/CommentItem.php
@@ -49,14 +49,13 @@ class CommentItem extends Component implements HasActions, HasForms
     {
         return $schema
             ->components([
-                RichEditor::make('body')
-                    ->hiddenLabel()
-                    ->required()
-                    ->placeholder(__('comments::comments.placeholder_edit'))
-                    ->toolbarButtons(CommentsConfig::getEditorToolbar())
-                    ->mentions([
-                        CommentsConfig::makeMentionProvider(),
-                    ]),
+                CommentsConfig::applyMentionProvider(
+                    RichEditor::make('body')
+                        ->hiddenLabel()
+                        ->required()
+                        ->placeholder(__('comments::comments.placeholder_edit'))
+                        ->toolbarButtons(CommentsConfig::getEditorToolbar())
+                ),
             ])
             ->statePath('editData');
     }
@@ -65,14 +64,13 @@ class CommentItem extends Component implements HasActions, HasForms
     {
         return $schema
             ->components([
-                RichEditor::make('body')
-                    ->hiddenLabel()
-                    ->required()
-                    ->placeholder(__('comments::comments.placeholder_reply'))
-                    ->toolbarButtons(CommentsConfig::getEditorToolbar())
-                    ->mentions([
-                        CommentsConfig::makeMentionProvider(),
-                    ]),
+                CommentsConfig::applyMentionProvider(
+                    RichEditor::make('body')
+                        ->hiddenLabel()
+                        ->required()
+                        ->placeholder(__('comments::comments.placeholder_reply'))
+                        ->toolbarButtons(CommentsConfig::getEditorToolbar())
+                ),
             ])
             ->statePath('replyData');
     }

--- a/src/Livewire/Comments.php
+++ b/src/Livewire/Comments.php
@@ -55,14 +55,13 @@ class Comments extends Component implements HasActions, HasForms
     {
         return $schema
             ->components([
-                RichEditor::make('body')
-                    ->hiddenLabel()
-                    ->required()
-                    ->placeholder(__('comments::comments.placeholder'))
-                    ->toolbarButtons(CommentsConfig::getEditorToolbar())
-                    ->mentions([
-                        CommentsConfig::makeMentionProvider(),
-                    ]),
+                CommentsConfig::applyMentionProvider(
+                    RichEditor::make('body')
+                        ->hiddenLabel()
+                        ->required()
+                        ->placeholder(__('comments::comments.placeholder'))
+                        ->toolbarButtons(CommentsConfig::getEditorToolbar())
+                ),
             ])
             ->statePath('commentData');
     }

--- a/src/Mentions/MentionParser.php
+++ b/src/Mentions/MentionParser.php
@@ -58,6 +58,10 @@ class MentionParser
 
     public function syncMentions(Comment $comment): void
     {
+        if (! CommentsConfig::areMentionsEnabled()) {
+            return;
+        }
+
         $newMentionIds = $this->parse($comment->body);
         $existingMentionIds = $comment->mentions()->pluck('comment_mentions.commenter_id');
 

--- a/src/Notifications/CommentRepliedNotification.php
+++ b/src/Notifications/CommentRepliedNotification.php
@@ -2,6 +2,7 @@
 
 namespace Relaticle\Comments\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Str;
@@ -21,13 +22,21 @@ class CommentRepliedNotification extends Notification
     /** @return array<string, mixed> */
     public function toDatabase(mixed $notifiable): array
     {
-        return [
-            'comment_id' => $this->comment->id,
-            'commentable_type' => $this->comment->commentable_type,
-            'commentable_id' => $this->comment->commentable_id,
-            'commenter_name' => $this->comment->commenter->getCommentDisplayName(),
-            'body' => Str::limit(strip_tags($this->comment->body), 100),
-        ];
+        $commenterName = $this->comment->commenter->getCommentDisplayName();
+
+        return array_merge(
+            FilamentNotification::make()
+                ->title(__('comments::comments.notifications.reply_body', ['name' => $commenterName]))
+                ->body($this->bodyExcerpt(100))
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->getDatabaseMessage(),
+            [
+                'comment_id' => $this->comment->id,
+                'commentable_type' => $this->comment->commentable_type,
+                'commentable_id' => $this->comment->commentable_id,
+                'commenter_name' => $commenterName,
+            ],
+        );
     }
 
     public function toMail(mixed $notifiable): MailMessage
@@ -37,6 +46,14 @@ class CommentRepliedNotification extends Notification
         return (new MailMessage)
             ->subject(__('comments::comments.notifications.reply_subject'))
             ->line(__('comments::comments.notifications.reply_body', ['name' => $commenterName]))
-            ->line(Str::limit(strip_tags($this->comment->body), 200));
+            ->line($this->bodyExcerpt(200));
+    }
+
+    protected function bodyExcerpt(int $limit): string
+    {
+        return Str::limit(
+            html_entity_decode(strip_tags($this->comment->body), ENT_QUOTES, 'UTF-8'),
+            $limit,
+        );
     }
 }

--- a/src/Notifications/UserMentionedNotification.php
+++ b/src/Notifications/UserMentionedNotification.php
@@ -2,6 +2,7 @@
 
 namespace Relaticle\Comments\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -25,13 +26,21 @@ class UserMentionedNotification extends Notification
     /** @return array<string, mixed> */
     public function toDatabase(mixed $notifiable): array
     {
-        return [
-            'comment_id' => $this->comment->id,
-            'commentable_type' => $this->comment->commentable_type,
-            'commentable_id' => $this->comment->commentable_id,
-            'mentioner_name' => $this->mentionedBy->getCommentDisplayName(),
-            'body' => Str::limit(strip_tags($this->comment->body), 100),
-        ];
+        $mentionerName = $this->mentionedBy->getCommentDisplayName();
+
+        return array_merge(
+            FilamentNotification::make()
+                ->title(__('comments::comments.notifications.mention_body', ['name' => $mentionerName]))
+                ->body($this->bodyExcerpt(100))
+                ->icon('heroicon-o-at-symbol')
+                ->getDatabaseMessage(),
+            [
+                'comment_id' => $this->comment->id,
+                'commentable_type' => $this->comment->commentable_type,
+                'commentable_id' => $this->comment->commentable_id,
+                'mentioner_name' => $mentionerName,
+            ],
+        );
     }
 
     public function toMail(mixed $notifiable): MailMessage
@@ -41,6 +50,14 @@ class UserMentionedNotification extends Notification
         return (new MailMessage)
             ->subject(__('comments::comments.notifications.mention_subject'))
             ->line(__('comments::comments.notifications.mention_body', ['name' => $mentionerName]))
-            ->line(Str::limit(strip_tags($this->comment->body), 200));
+            ->line($this->bodyExcerpt(200));
+    }
+
+    protected function bodyExcerpt(int $limit): string
+    {
+        return Str::limit(
+            html_entity_decode(strip_tags($this->comment->body), ENT_QUOTES, 'UTF-8'),
+            $limit,
+        );
     }
 }

--- a/tests/Feature/MentionSearchTest.php
+++ b/tests/Feature/MentionSearchTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Livewire\Livewire;
+use Relaticle\Comments\CommentsConfig;
 use Relaticle\Comments\Livewire\CommentItem;
 use Relaticle\Comments\Livewire\Comments;
 use Relaticle\Comments\Models\Comment;
@@ -48,4 +49,16 @@ it('stores mentions when editing comment with @mention', function () {
 
     expect($comment->mentions)->toHaveCount(1);
     expect($comment->mentions->first()->id)->toBe($bob->id);
+});
+
+it('orders mention search results by the first search column, not the name column', function () {
+    config()->set('comments.mentions.search_columns', ['name']);
+    config()->set('comments.mentions.name_column', 'email');
+
+    $first = User::factory()->create(['name' => 'Aaron Example', 'email' => 'zzz@example.com']);
+    User::factory()->create(['name' => 'Zoe Example', 'email' => 'aaa@example.com']);
+
+    $results = CommentsConfig::makeMentionProvider()->getSearchResults('Example');
+
+    expect((int) array_key_first($results))->toBe((int) $first->getKey());
 });

--- a/tests/Feature/MentionsDisabledTest.php
+++ b/tests/Feature/MentionsDisabledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Filament\Forms\Components\RichEditor;
+use Illuminate\Support\Facades\Event;
+use Relaticle\Comments\CommentsConfig;
+use Relaticle\Comments\Events\UserMentioned;
+use Relaticle\Comments\Mentions\MentionParser;
+use Relaticle\Comments\Models\Comment;
+use Relaticle\Comments\Tests\Models\Post;
+use Relaticle\Comments\Tests\Models\User;
+
+it('is enabled by default', function () {
+    expect(config('comments.mentions.enabled'))->toBeTrue();
+});
+
+it('does not sync mentions when mentions are disabled', function () {
+    config()->set('comments.mentions.enabled', false);
+
+    Event::fake([UserMentioned::class]);
+
+    $user = User::factory()->create();
+    User::factory()->create(['name' => 'john']);
+    $post = Post::factory()->create();
+
+    $comment = Comment::factory()->create([
+        'commentable_id' => $post->id,
+        'commentable_type' => $post->getMorphClass(),
+        'commenter_id' => $user->getKey(),
+        'commenter_type' => $user->getMorphClass(),
+        'body' => '<p>Hello @john</p>',
+    ]);
+
+    app(MentionParser::class)->syncMentions($comment);
+
+    expect($comment->mentions()->count())->toBe(0);
+    Event::assertNotDispatched(UserMentioned::class);
+});
+
+it('attaches the mention provider to the editor when enabled', function () {
+    $editor = CommentsConfig::applyMentionProvider(RichEditor::make('body'));
+
+    expect($editor->hasMentions())->toBeTrue();
+});
+
+it('does not attach the mention provider to the editor when disabled', function () {
+    config()->set('comments.mentions.enabled', false);
+
+    $editor = CommentsConfig::applyMentionProvider(RichEditor::make('body'));
+
+    expect($editor->hasMentions())->toBeFalse();
+});

--- a/tests/Feature/MigrationStubsTest.php
+++ b/tests/Feature/MigrationStubsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+it('ships migration stubs that are valid PHP', function () {
+    $stubs = glob(dirname(__DIR__, 2).'/database/migrations/*.php.stub');
+
+    expect($stubs)->not->toBeEmpty();
+
+    foreach ($stubs as $stub) {
+        try {
+            token_get_all((string) file_get_contents($stub), TOKEN_PARSE);
+        } catch (ParseError $e) {
+            $this->fail(basename($stub).' contains a syntax error: '.$e->getMessage());
+        }
+    }
+});
+
+it('runs the published migration stubs and names long indexes explicitly', function () {
+    $connection = 'stub_migration_test';
+
+    config()->set("database.connections.{$connection}", [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+
+    $stubDir = dirname(__DIR__, 2).'/database/migrations';
+    $tmpDir = sys_get_temp_dir().'/comments_migrations_'.Str::random(8);
+    mkdir($tmpDir);
+
+    $ordered = [
+        'create_comments_table',
+        'create_comment_mentions_table',
+        'create_comment_reactions_table',
+        'create_comment_subscriptions_table',
+        'create_comment_attachments_table',
+        'add_pinned_at_to_comments_table',
+    ];
+
+    foreach ($ordered as $index => $name) {
+        copy(
+            "{$stubDir}/{$name}.php.stub",
+            sprintf('%s/2024_01_01_0000%02d_%s.php', $tmpDir, $index, $name),
+        );
+    }
+
+    try {
+        $this->artisan('migrate', [
+            '--database' => $connection,
+            '--path' => $tmpDir,
+            '--realpath' => true,
+        ])->assertSuccessful();
+
+        expect(Schema::connection($connection)->hasTable('comments'))->toBeTrue()
+            ->and(Schema::connection($connection)->hasTable('comment_reactions'))->toBeTrue();
+
+        $indexNames = collect(DB::connection($connection)->select("PRAGMA index_list('comment_reactions')"))
+            ->pluck('name');
+
+        expect($indexNames)->toContain('comment_reactions_unique');
+
+        foreach ($indexNames as $indexName) {
+            expect(strlen((string) $indexName))->toBeLessThanOrEqual(63);
+        }
+    } finally {
+        array_map('unlink', glob("{$tmpDir}/*") ?: []);
+        @rmdir($tmpDir);
+    }
+});

--- a/tests/Feature/MigrationStubsTest.php
+++ b/tests/Feature/MigrationStubsTest.php
@@ -57,12 +57,15 @@ it('runs the published migration stubs and names long indexes explicitly', funct
         expect(Schema::connection($connection)->hasTable('comments'))->toBeTrue()
             ->and(Schema::connection($connection)->hasTable('comment_reactions'))->toBeTrue();
 
-        $indexNames = collect(DB::connection($connection)->select("PRAGMA index_list('comment_reactions')"))
+        $reactionIndexes = collect(DB::connection($connection)->select("PRAGMA index_list('comment_reactions')"))
+            ->pluck('name');
+        $mentionIndexes = collect(DB::connection($connection)->select("PRAGMA index_list('comment_mentions')"))
             ->pluck('name');
 
-        expect($indexNames)->toContain('comment_reactions_unique');
+        expect($reactionIndexes)->toContain('comment_reactions_unique')
+            ->and($mentionIndexes)->toContain('comment_mentions_unique');
 
-        foreach ($indexNames as $indexName) {
+        foreach ($reactionIndexes->merge($mentionIndexes) as $indexName) {
             expect(strlen((string) $indexName))->toBeLessThanOrEqual(63);
         }
     } finally {
@@ -70,3 +73,41 @@ it('runs the published migration stubs and names long indexes explicitly', funct
         @rmdir($tmpDir);
     }
 });
+
+it('creates a nullable tenant column when multi-tenancy is enabled', function (string $type) {
+    config()->set('comments.multi_tenancy.enabled', true);
+    config()->set('comments.multi_tenancy.tenant_column', 'tenant_id');
+    config()->set('comments.multi_tenancy.tenant_column_type', $type);
+
+    $connection = 'stub_tenant_test';
+
+    config()->set("database.connections.{$connection}", [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+
+    $stubDir = dirname(__DIR__, 2).'/database/migrations';
+    $tmpDir = sys_get_temp_dir().'/comments_tenant_'.Str::random(8);
+    mkdir($tmpDir);
+    copy("{$stubDir}/create_comments_table.php.stub", "{$tmpDir}/2024_01_01_000001_create_comments_table.php");
+
+    try {
+        $this->artisan('migrate', [
+            '--database' => $connection,
+            '--path' => $tmpDir,
+            '--realpath' => true,
+        ])->assertSuccessful();
+
+        expect(Schema::connection($connection)->hasColumn('comments', 'tenant_id'))->toBeTrue();
+
+        $tenantColumn = collect(Schema::connection($connection)->getColumns('comments'))
+            ->firstWhere('name', 'tenant_id');
+
+        expect($tenantColumn)->not->toBeNull()
+            ->and($tenantColumn['nullable'])->toBeTrue();
+    } finally {
+        array_map('unlink', glob("{$tmpDir}/*") ?: []);
+        @rmdir($tmpDir);
+    }
+})->with(['unsignedBigInteger', 'uuid', 'string']);

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -31,7 +31,7 @@ it('returns correct via channels from config for CommentRepliedNotification', fu
     expect($notification->via($user))->toBe(['database', 'mail']);
 });
 
-it('returns toDatabase array with comment data for CommentRepliedNotification', function () {
+it('returns a filament-format toDatabase payload for CommentRepliedNotification', function () {
     $user = User::factory()->create();
     $post = Post::factory()->create();
 
@@ -40,17 +40,38 @@ it('returns toDatabase array with comment data for CommentRepliedNotification', 
         'commentable_type' => $post->getMorphClass(),
         'commenter_id' => $user->getKey(),
         'commenter_type' => $user->getMorphClass(),
-        'body' => '<p>This is a reply body</p>',
+        'body' => '<p>This is a reply to @bob</p>',
     ]);
 
     $notification = new CommentRepliedNotification($comment);
     $data = $notification->toDatabase($user);
 
-    expect($data)->toHaveKeys(['comment_id', 'commentable_type', 'commentable_id', 'commenter_name', 'body'])
+    expect($data)->toHaveKeys(['format', 'title', 'body', 'comment_id', 'commentable_type', 'commentable_id', 'commenter_name'])
+        ->and($data['format'])->toBe('filament')
         ->and($data['comment_id'])->toBe($comment->id)
         ->and($data['commentable_type'])->toBe($post->getMorphClass())
         ->and($data['commentable_id'])->toBe($post->id)
-        ->and($data['commenter_name'])->toBe($user->getCommentDisplayName());
+        ->and($data['commenter_name'])->toBe($user->getCommentDisplayName())
+        ->and($data['body'])->toContain('@bob')
+        ->and($data['body'])->not->toContain('&#64;');
+});
+
+it('decodes html entities in the CommentRepliedNotification mail body', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+
+    $comment = Comment::factory()->create([
+        'commentable_id' => $post->id,
+        'commentable_type' => $post->getMorphClass(),
+        'commenter_id' => $user->getKey(),
+        'commenter_type' => $user->getMorphClass(),
+        'body' => '<p>Reply mentioning @bob here</p>',
+    ]);
+
+    $mail = (new CommentRepliedNotification($comment))->toMail($user);
+    $lines = implode("\n", array_merge($mail->introLines, $mail->outroLines));
+
+    expect($lines)->toContain('@bob')->not->toContain('&#64;');
 });
 
 it('returns correct via channels from config for UserMentionedNotification', function () {
@@ -73,7 +94,7 @@ it('returns correct via channels from config for UserMentionedNotification', fun
     expect($notification->via($user))->toBe(['database']);
 });
 
-it('returns toDatabase array with mention data for UserMentionedNotification', function () {
+it('returns a filament-format toDatabase payload for UserMentionedNotification', function () {
     $mentioner = User::factory()->create();
     $mentioned = User::factory()->create();
     $post = Post::factory()->create();
@@ -83,15 +104,18 @@ it('returns toDatabase array with mention data for UserMentionedNotification', f
         'commentable_type' => $post->getMorphClass(),
         'commenter_id' => $mentioner->getKey(),
         'commenter_type' => $mentioner->getMorphClass(),
-        'body' => '<p>Hey @mentioned</p>',
+        'body' => '<p>Hey @mentioned welcome aboard</p>',
     ]);
 
     $notification = new UserMentionedNotification($comment, $mentioner);
     $data = $notification->toDatabase($mentioned);
 
-    expect($data)->toHaveKeys(['comment_id', 'commentable_type', 'commentable_id', 'mentioner_name', 'body'])
+    expect($data)->toHaveKeys(['format', 'title', 'body', 'comment_id', 'commentable_type', 'commentable_id', 'mentioner_name'])
+        ->and($data['format'])->toBe('filament')
         ->and($data['comment_id'])->toBe($comment->id)
-        ->and($data['mentioner_name'])->toBe($mentioner->getCommentDisplayName());
+        ->and($data['mentioner_name'])->toBe($mentioner->getCommentDisplayName())
+        ->and($data['body'])->toContain('@mentioned')
+        ->and($data['body'])->not->toContain('&#64;');
 });
 
 it('sends notification to subscribers when reply comment is created', function () {


### PR DESCRIPTION
Fixes a batch of issues reported against `1.x` (default config). Each was reproduced locally before fixing, and each now has a regression test.

## Why these shipped undetected

The test suite hand-writes the schema in `tests/TestCase.php` against **SQLite in-memory** — it never published or ran the actual migration stubs, and SQLite masks two of these bugs (no 64-char index limit; `ORDER BY "missing_col"` silently degrades to a string literal instead of erroring). This PR adds a migration test that publishes and runs the real stubs.

## Fixes

### 1. Migrations

**Fatal parse error in every stub (P0).** The tenant-column block chained a method onto a `match` statement:

```php
match (config('comments.multi_tenancy.tenant_column_type', 'unsignedBigInteger')) {
    ...
}->nullable()->index();   // Parse error: unexpected token "->"
```

`match {...}->method()` is not valid PHP as a statement — this is a **compile-time** error, so it fires regardless of `multi_tenancy.enabled`. It affects all 5 table stubs and has been in released `v1.0.3` since 2026-05-07, meaning `vendor:publish` + `migrate` fails on a fresh install. Fixed by wrapping the `match` in parentheses.

**`comment_reactions` unique index name too long.** The unnamed composite unique produced a 72-char auto name (`comment_reactions_comment_id_commenter_id_commenter_type_reaction_unique`), exceeding MySQL's 64-char identifier limit. Added an explicit `comment_reactions_unique` name, matching what `comment_subscriptions` already does.

### 2. Multi-column mention search ordered by `name`

`makeMentionProvider()` ordered results by `mentions.name_column` (default `name`) even when searching other columns. For apps whose display name is composed of multiple columns (the exact case the config docstring describes), `name` may not exist — SQL error on Postgres/MySQL. Now orders by the first configured search column.

### 3. Notifications

**Database notifications didn't appear in the Filament tray.** The `toDatabase()` payload was a plain Laravel array with no `format` key. Filament's tray queries `where('data->format', 'filament')`, so the rows were filtered out entirely. `toDatabase()` now returns a Filament-format message (via `Notification::make()->...->getDatabaseMessage()`), merged with the existing metadata keys for back-compat.

**Mail/database body showed `&#64;` instead of `@`.** The HTML sanitizer encodes `@` → `&#64;` on save, and `strip_tags()` doesn't decode entities. Excerpts now run through `html_entity_decode()` (mirroring `MentionParser`), so mentions read as `@name`.

### 4. Ability to disable mentions

Added a `mentions.enabled` config flag (default `true`). When `false`, the mention provider is not attached to the editor and `MentionParser::syncMentions()` is a no-op (no mention rows, no `UserMentioned` events/notifications).

## Test plan

- `vendor/bin/pest` — 257 passing (was 249; +8 net)
- `vendor/bin/pint --test` — clean
- New/updated tests:
  - `MigrationStubsTest` — stubs parse; publishing + running them creates tables with index names ≤ 63 chars
  - `MentionSearchTest` — search orders by the search column, not `name_column`
  - `NotificationTest` — `toDatabase()` payload is `format: filament`; mail/db bodies decode `@`
  - `MentionsDisabledTest` — mentions off ⇒ no sync, no event, provider not attached

## Follow-up hardening (post-review)

- Gave `comment_mentions` an explicit `comment_mentions_unique` index name too — its auto-generated name was 62 chars (1 under Postgres's 63 limit) and would overflow under a table prefix or a longer `table_names.mentions`. Same class as the reactions fix.
- Added a migration test that runs with `multi_tenancy.enabled=true` across all three `tenant_column_type` values (`unsignedBigInteger`/`uuid`/`string`), asserting the tenant column is created and nullable — so the wrapped `match` block is now covered at runtime, not just parse-time.
- Verified the `toDatabase()` Filament-format change on **both Filament v4 and v5** (full suite green on each) and added a `filament: [4, 5]` leg to the CI matrix so the declared `^4.0|^5.0` range is actually exercised.

## Note (not addressed here)

The mention search loops `where(...)->orWhere(...)` without grouping. This only matters if a consuming app adds its own global scope to the commenter (User) model: the search queries the **User** model, which this package does not tenant-scope (the package's `TenantScope` applies to `Comment`, not `User`). In that case the ungrouped OR could widen results past the host's scope. Pre-existing and out of scope here (this PR only changes the `orderBy` argument) — worth grouping the OR into a closure in a follow-up.
