### PR TITLE
fix: pin comment form to slide-over bottom without external CSS [1.x]

### DIFF
--- a/resources/views/livewire/comments.blade.php
+++ b/resources/views/livewire/comments.blade.php
@@ -1,4 +1,10 @@
+{{--
+    The flex layout that pins the comment form to the bottom of the slide-over is
+    inlined so it works even when the stylesheet served by CommentsStyleController
+    is unavailable (blocked route, proxy, stale cache) — see issue #28.
+--}}
 <div class="comments-wrap"
+    style="display: flex; flex-direction: column; flex: 1 1 0%; min-height: 0;"
     @if (!\Relaticle\Comments\CommentsConfig::isBroadcastingEnabled())
         wire:poll.{{ \Relaticle\Comments\CommentsConfig::getPollingInterval() }}
     @endif
@@ -6,7 +12,7 @@
     x-on:livewire-upload-error.window="uploadError = {{ Illuminate\Support\Js::from(__('comments::comments.attachments.upload_failed')) }}"
     x-on:livewire-upload-start.window="uploadError = null"
 >
-    <div class="comments-body space-y-4">
+    <div class="comments-body space-y-4" style="flex: 1 1 0%; min-height: 0; overflow-y: auto;">
     {{-- Sort toggle --}}
     <div class="flex items-center justify-between">
         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -87,7 +93,8 @@
     {{-- New comment form - sticky at bottom of slide-over --}}
     @auth
         @can('create', \Relaticle\Comments\CommentsConfig::getCommentModel())
-            <div class="shrink-0 border-t border-gray-200 bg-white px-6 pt-3 dark:border-gray-700 dark:bg-gray-900 -mx-6">                {{ $this->commentForm }}
+            <div class="shrink-0 border-t border-gray-200 bg-white px-6 pt-3 dark:border-gray-700 dark:bg-gray-900 -mx-6" style="flex-shrink: 0;">
+                {{ $this->commentForm }}
 
                 @if (!empty($attachments))
                     <div class="mt-2 flex flex-wrap gap-2">


### PR DESCRIPTION
Closes #28

## Problem

The comment composer is meant to be pinned to the bottom of the slide-over, with the comment list scrolling above it. That layout lives exclusively in `resources/css/comments.css`, served at runtime via the `/__relaticle-comments/css` route registered as a Filament asset.

When that one stylesheet fails to load or apply (blocked/rewritten route behind a proxy, stale cache, or stale published views), `.comments-wrap` falls back to block layout: the composer renders directly under the last comment and dead space fills the rest of the panel — exactly the screenshot in #28. Theme-compiled Tailwind utilities keep everything else looking styled, which is why the breakage looks so selective.

Reproduced against Filament v4.12 and v5.4 by removing the `__relaticle-comments/css` stylesheet from a working install: layout collapses into the reported state. The blade markup, CSS rules, and Filament modal DOM are otherwise identical from v4.0.0 through 5.x, so version drift was ruled out as the cause.

## Fix

Inline the three critical layout declarations into the component markup itself, so pinning no longer depends on a second network-delivered stylesheet:

- `.comments-wrap`: `display:flex; flex-direction:column; flex:1 1 0%; min-height:0`
- `.comments-body`: `flex:1 1 0%; min-height:0; overflow-y:auto`
- form footer: `flex-shrink:0`

`comments.css` keeps the same rules, so apps that published older views (without these inline styles) still get pinned layout whenever the stylesheet does load.

## Verification

- Repro (stylesheet removed, before fix): composer sits under the list, dead space below — matches #28.
- Same repro after fix: composer pinned to the bottom, list area scrolls (`.comments-wrap` stays a flex column with no stylesheet present).
- Verified in light and dark mode inside a real Filament v5 host app; package suite: 260 passed (553 assertions).