### PR TITLE
fix: mention autocomplete bypasses the configured MentionResolver [1.x]

### DIFF
--- a/src/CommentsConfig.php
+++ b/src/CommentsConfig.php
@@ -7,6 +7,7 @@ use Closure;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\MentionProvider;
 use Illuminate\Support\Facades\Gate;
+use Relaticle\Comments\Contracts\MentionResolver as MentionResolverContract;
 use Relaticle\Comments\Mentions\DefaultMentionResolver;
 use Relaticle\Comments\Models\Comment;
 use Relaticle\Comments\Policies\CommentPolicy;
@@ -285,21 +286,10 @@ class CommentsConfig
     public static function makeMentionProvider(): MentionProvider
     {
         return MentionProvider::make('@')
-            ->getSearchResultsUsing(function (string $search): array {
-                $query = static::getCommenterModel()::query();
-
-                foreach (static::getMentionSearchColumns() as $index => $column) {
-                    $method = $index === 0 ? 'where' : 'orWhere';
-                    $query->{$method}($column, 'like', "%{$search}%");
-                }
-
-                return $query
-                    ->orderBy(static::getMentionSearchColumns()[0])
-                    ->limit(static::getMentionMaxResults())
-                    ->get()
-                    ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
-                    ->all();
-            })
+            ->getSearchResultsUsing(fn (string $search): array => app(MentionResolverContract::class)
+                ->search($search)
+                ->mapWithKeys(fn ($user) => [$user->getKey() => static::getUserName($user)])
+                ->all())
             ->getLabelsUsing(fn (array $ids): array => static::getCommenterModel()::query()
                 ->whereIn('id', $ids)
                 ->get()

--- a/src/Mentions/DefaultMentionResolver.php
+++ b/src/Mentions/DefaultMentionResolver.php
@@ -14,13 +14,15 @@ class DefaultMentionResolver implements MentionResolver
     {
         $model = CommentsConfig::getCommenterModel();
         $builder = $model::query();
+        $columns = CommentsConfig::getMentionSearchColumns();
 
-        foreach (CommentsConfig::getMentionSearchColumns() as $index => $column) {
+        foreach ($columns as $index => $column) {
             $method = $index === 0 ? 'where' : 'orWhere';
-            $builder->{$method}($column, 'like', "{$query}%");
+            $builder->{$method}($column, 'like', "%{$query}%");
         }
 
         return $builder
+            ->orderBy($columns[0])
             ->limit(CommentsConfig::getMentionMaxResults())
             ->get();
     }

--- a/tests/Feature/MentionSearchTest.php
+++ b/tests/Feature/MentionSearchTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Illuminate\Support\Collection;
 use Livewire\Livewire;
 use Relaticle\Comments\CommentsConfig;
+use Relaticle\Comments\Contracts\MentionResolver;
 use Relaticle\Comments\Livewire\CommentItem;
 use Relaticle\Comments\Livewire\Comments;
 use Relaticle\Comments\Models\Comment;
@@ -61,4 +63,26 @@ it('orders mention search results by the first search column, not the name colum
     $results = CommentsConfig::makeMentionProvider()->getSearchResults('Example');
 
     expect((int) array_key_first($results))->toBe((int) $first->getKey());
+});
+
+it('delegates mention autocomplete to the bound mention resolver', function () {
+    $alice = User::factory()->create(['name' => 'Alice']);
+    User::factory()->create(['name' => 'Alicia']);
+
+    app()->bind(MentionResolver::class, fn () => new class implements MentionResolver
+    {
+        public function search(string $query): Collection
+        {
+            return User::query()->where('name', 'Alice')->get();
+        }
+
+        public function resolveByNames(array $names): Collection
+        {
+            return User::query()->whereIn('name', $names)->get();
+        }
+    });
+
+    $results = CommentsConfig::makeMentionProvider()->getSearchResults('Ali');
+
+    expect($results)->toBe([$alice->getKey() => 'Alice']);
 });


### PR DESCRIPTION
## Problem

`CommentsConfig::makeMentionProvider()` builds the editor's @-autocomplete with its own inline query against the commenter model — the configured `MentionResolver` (`comments.mentions.resolver`) is never consulted. `MentionResolver::search()` is effectively dead code in the shipped flow: only `resolveByNames()` runs (at comment-save time via `MentionParser`).

Consequences:

- A custom resolver is silently ignored where it matters most. In a multi-tenant host app, a tenant-scoped resolver still leaks **every user in the users table** through autocomplete suggestions.
- Autocomplete and mention persistence can disagree: suggestions come from one query, saved mentions from another.

## Fix

- `makeMentionProvider()` now delegates search to the container-bound `MentionResolver` and only maps the results to `[key => display name]`.
- `DefaultMentionResolver::search()` adopts the exact semantics the inline query had (infix `%search%` match across `search_columns`, ordered by the first search column, limited to `max_results`), so default installs see byte-identical autocomplete behavior.
- New test: binding a custom resolver is respected by `makeMentionProvider()->getSearchResults()`.

`getLabelsUsing()` (IDs → display names when re-rendering saved mentions) still queries the commenter model directly: the `MentionResolver` contract has no resolve-by-ids method, and adding one would break existing custom resolvers. The IDs it receives originate from previously scoped suggestions, so the exposure autocomplete had does not apply there. Worth revisiting in 2.x.

## Verification

- Package suite: 261 passed (554 assertions), including the new delegation test.
- PHPStan: same 97 pre-existing errors as clean `1.x` — no new errors introduced.