### PR TITLE
docs: remove alpha software notice [1.x]

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -14,10 +14,6 @@ A full-featured commenting system for Filament panels with threaded replies, @me
 
 Drop-in integration with any Filament resource.
 
-:::callout{icon="i-lucide-triangle-alert" color="amber"}
-**Alpha Software** — Breaking changes may occur between releases. Not recommended for production use.
-:::
-
 #links
   :::u-button
   ---


### PR DESCRIPTION
The package is stable (1.x releases on Packagist, no planned breaking changes between releases), so the docs hero no longer flags it as alpha software. This was the only alpha marker left in the repo — README and the rest of the docs carry none.