### PR TITLE
chore: update dev dependencies, allow pest 5, test laravel 13 in ci [1.x]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,21 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         filament: [4, 5]
         stability: [prefer-stable]
         exclude:
           # Filament 5 pulls Livewire 4 / pest-plugin-livewire 4, which need PHP 8.3+
           - php: 8.2
             filament: 5
+          # Laravel 13 needs PHP 8.3+
+          - php: 8.2
+            laravel: 13.*
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "laravel/pint": "^1.0",
         "larastan/larastan": "^3.0",
         "orchestra/testbench": "^10.0|^11.0",
-        "pestphp/pest": "^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
-        "pestphp/pest-plugin-livewire": "^3.0|^4.0"
+        "pestphp/pest": "^3.0|^4.0|^5.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0|^5.0",
+        "pestphp/pest-plugin-livewire": "^3.0|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dependency refresh ahead of the next release. Runtime constraints were already current (`filament ^4|^5`, `livewire ^3.5|^4`, `illuminate ^12|^13`, `spatie/laravel-package-tools ^1.93` all cover today's latest releases), so the actual changes are:

- **Pest 5 support**: `pestphp/pest` + both plugins widened to `^3.0|^4.0|^5.0`. Pest 5 requires PHP 8.4, so PHP 8.2/8.3 environments keep resolving Pest 3/4 — additive only.
- **Laravel 13 in the CI matrix**: the composer constraint has claimed `illuminate ^13` support without CI ever exercising it. Added `13.*` (testbench `11.*`) with a PHP 8.2 exclusion (Laravel 13 requires PHP 8.3+). Matrix goes from 5 to 9 jobs.

`composer.lock` is gitignored here, so there is nothing else to commit — each CI cell resolves fresh.

## Verification (local, PHP 8.4)

Fresh `composer update` resolved the full bleeding-edge cell — Laravel 13.25, Filament 5.7.6, Livewire 4.4.0, testbench 11.2, Pest 5.1.1, Larastan 3.10, Pint 1.30.5 — and on that stack:

- `vendor/bin/pest --ci`: 261 passed (554 assertions)
- `vendor/bin/pint --test`: clean (no style drift with Pint 1.30.5)
- `vendor/bin/phpstan analyse`: same 97 pre-existing errors as before the update — Larastan 3.10 introduces no new ones

The remaining cells (Pest 3/4 on PHP 8.2/8.3, Filament 4, Laravel 12) are covered by the CI matrix on this PR.