### PR TITLE
fix: mention ids are dropped for ulid/uuid commenter keys [1.x]

### DIFF
--- a/src/Mentions/MentionParser.php
+++ b/src/Mentions/MentionParser.php
@@ -14,7 +14,7 @@ class MentionParser
         protected MentionResolver $resolver,
     ) {}
 
-    /** @return Collection<int, int> */
+    /** @return Collection<int, int|string> */
     public function parse(string $body): Collection
     {
         $ids = $this->parseRichEditorMentions($body);
@@ -26,21 +26,29 @@ class MentionParser
         return $this->parsePlainTextMentions($body);
     }
 
-    /** @return Collection<int, int> */
+    /**
+     * Commenter keys may be integers, ULIDs, or UUIDs — the id is captured
+     * verbatim, with numeric strings normalised back to int for integer keys.
+     *
+     * @return Collection<int, int|string>
+     */
     protected function parseRichEditorMentions(string $body): Collection
     {
-        preg_match_all('/data-type=["\']mention["\'][^>]*data-id=["\'](\d+)["\']/', $body, $matches);
+        preg_match_all('/data-type=["\']mention["\'][^>]*data-id=["\']([^"\']+)["\']/', $body, $matches);
 
         if (empty($matches[1])) {
-            preg_match_all('/data-id=["\'](\d+)["\'][^>]*data-type=["\']mention["\']/', $body, $matches);
+            preg_match_all('/data-id=["\']([^"\']+)["\'][^>]*data-type=["\']mention["\']/', $body, $matches);
         }
 
-        $ids = array_unique(array_map('intval', $matches[1] ?? []));
+        $ids = array_map(
+            fn (string $id): int|string => is_numeric($id) ? (int) $id : $id,
+            array_unique($matches[1] ?? []),
+        );
 
-        return collect($ids);
+        return collect(array_values($ids));
     }
 
-    /** @return Collection<int, int> */
+    /** @return Collection<int, int|string> */
     protected function parsePlainTextMentions(string $body): Collection
     {
         $text = html_entity_decode(strip_tags($body), ENT_QUOTES, 'UTF-8');

--- a/tests/Feature/MentionParserTest.php
+++ b/tests/Feature/MentionParserTest.php
@@ -21,6 +21,15 @@ it('parses rich-editor mention spans using data-id', function () {
     expect($result->first())->toBe($john->id);
 });
 
+it('parses rich-editor mention spans whose data-id is not an integer (ulid/uuid commenter keys)', function () {
+    $parser = app(MentionParser::class);
+    $body = '<p><span data-type="mention" data-id="01m07ry393v7mkm33trc26h8dr" data-label="Tessa" data-char="@">@Tessa</span></p>';
+
+    $result = $parser->parse($body);
+
+    expect($result->all())->toBe(['01m07ry393v7mkm33trc26h8dr']);
+});
+
 it('parses @username from plain text body', function () {
     User::factory()->create(['name' => 'john']);
     User::factory()->create(['name' => 'jane']);


### PR DESCRIPTION
## Problem

`MentionParser::parseRichEditorMentions()` captures `data-id=["'](\d+)["']` — digits only — and runs the matches through `intval`. When the commenter model uses ULID or UUID primary keys, the editor's mention span (`data-id="01m07ry…"`) never matches, the plain-text fallback extracts a single word that resolves to no user, and mention persistence fails **silently**: the mention chip renders in the comment body, but no `comment_mentions` row is written and no `UserMentioned` notification goes out.

Reproduced end-to-end in a ULID-keyed host app (Relaticle) on v1.1: @-autocomplete suggested the teammate, the posted comment rendered the chip, `comment_mentions` stayed empty, mentioned user received nothing.

## Fix

Capture the `data-id` value verbatim (`[^"']+`), normalising numeric strings back to `int` so integer-keyed apps keep byte-identical behavior (existing tests assert strict int ids). Docblocks widened to `Collection<int, int|string>`.

## Verification

- New regression test: a mention span with a ULID `data-id` parses to that id — red before the fix, green after.
- Full suite: 262 passed (555 assertions); Pint clean.
- Re-verified the original repro in the host app against this branch: mention row written and database notification delivered to the mentioned user.