### PR TITLE
chore(ci): pin actions to commit SHAs, add cooldown, lean dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+phpstan.neon.dist export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,20 +1,24 @@
 name: Auto-Merge
 
-on: pull_request_target
+on: pull_request
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,28 +14,31 @@ jobs:
     steps:
       - name: Determine target branch
         id: branch
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           MAJOR=$(echo "$TAG" | sed -E 's/^v?([0-9]+)\..*/\1/')
           BRANCH="${MAJOR}.x"
-          if ! git ls-remote --exit-code --heads "https://github.com/${{ github.repository }}" "$BRANCH" > /dev/null 2>&1; then
-            BRANCH="${{ github.event.repository.default_branch }}"
+          if ! git ls-remote --exit-code --heads "https://github.com/$REPO" "$BRANCH" > /dev/null 2>&1; then
+            BRANCH="$DEFAULT_BRANCH"
           fi
-          echo "name=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.branch.outputs.name }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           branch: ${{ steps.branch.outputs.name }}
           commit_message: Update CHANGELOG

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,18 +53,18 @@ jobs:
           esac
 
       - name: Checkout source branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.branch }}
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: Fix styling

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,41 +6,46 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
-    secrets: inherit
 
   release:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine if pre-release
         id: prerelease
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           if [[ "$TAG" == *"-"* ]]; then
-            echo "flag=--prerelease" >> $GITHUB_OUTPUT
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
           else
-            echo "flag=" >> $GITHUB_OUTPUT
+            echo "flag=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE_FLAG: ${{ steps.prerelease.outputs.flag }}
         run: |
-          TAG="${{ github.ref_name }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping creation."
             exit 0
           fi
-          gh release create "$TAG" --generate-notes ${{ steps.prerelease.outputs.flag }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          gh release create "$TAG" --generate-notes $PRERELEASE_FLAG
 
   cleanup:
     needs: tests
@@ -51,7 +56,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Delete tag on test failure
-        run: git push --delete origin "${{ github.ref_name }}"
+        env:
+          TAG: ${{ github.ref_name }}
+        run: git push --delete origin "$TAG"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,37 @@ on:
     branches: [1.x]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
+  actions-pinned:
+    name: Actions pinned to SHA
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Assert every third-party action is pinned to a full commit SHA
+        run: |
+          unpinned=$(grep -rhoE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows \
+            | sed -E 's/.*uses:[[:space:]]*//' \
+            | grep -v '^\./' \
+            | grep -vE '@[0-9a-f]{40}$' \
+            | sort -u || true)
+
+          if [ -n "$unpinned" ]; then
+            echo "Third-party actions must be pinned to a full 40-character commit SHA."
+            echo "Unpinned references:"
+            echo "$unpinned" | sed 's/^/  /'
+            exit 1
+          fi
+
+          echo "All third-party action references are pinned to a full commit SHA."
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -35,10 +65,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Takes the package from **79.31 to 100** on [Plumb](https://plumbphp.dev/relaticle/comments), the audit behind the Filament plugin directory badge. Same treatment as Relaticle/flowforge#168 and #169.

## Plumb checks

| Check | Weight | Before | After |
|---|---|---|---|
| `security.actions-sha-pinned` | 8 | fail, 0 of 14 pinned | pass, 17 of 17 |
| `security.dependency-update-cooldown` | 4 | fail, no cooldown | pass, 7 days |
| `maintenance.lean-dist` | 4 | **warn** (0.5) | pass |

Security 67.57 to 100, Maintenance 90.48 to 100. Composite is `0.55*security + 0.30*maintenance + 0.15*ecosystem`, a formula I derived and validated to the second decimal against four scanned packages, so **79.31 to 100.00**.

`lean-dist` is worth calling out because it shows as a pass on the plugin page while only scoring half credit. It was dropping points for shipping `phpstan.neon.dist`, which the new `.gitattributes` excludes.

## Pins

14 refs resolved through the GitHub API, each SHA cross-checked against the tag object it dereferences to. `actions/checkout` and `shivammathur/setup-php` match byte-for-byte what `bezhanSalleh/filament-shield` ships.

The trailing version comments are load-bearing: Dependabot reads them to know the current version, so `auto-merge.yml` keeps classifying updates correctly after pinning. This repo has a track record of Dependabot action bumps merging cleanly (#19, #25, #27), so that loop is known to work here.

## zizmor

`zizmor 1.29.0` reported 5 high findings on the workflows. All fixed:

| Rule | Where | Fix |
|---|---|---|
| `dangerous-triggers` | `auto-merge.yml` | `pull_request_target` to `pull_request` |
| `bot-conditions` | `auto-merge.yml` | `github.actor` to `github.event.pull_request.user.login` |
| `excessive-permissions` | `release.yml` | `contents: write` moved from workflow level to the job that needs it |
| `secrets-inherit` | `release.yml` | dropped; `tests.yml` reads no secrets |
| `template-injection` x3 | `changelog.yml`, `release.yml` | release tag, repo and default branch passed via `env:` instead of interpolated into `run` |

`auto-merge.yml` now matches [GitHub's documented pattern](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions): `on: pull_request` with permissions elevated per job. Dependabot-triggered `pull_request` runs get a read-only token by default, which is why permissions are declared on the job. `laravel/framework` runs this exact shape in production.

## Regression guards

- `actions-pinned` job in `tests.yml` fails on any third-party `uses:` lacking a 40-hex SHA. `release.yml` calls `tests.yml` via `workflow_call`, so releases are gated on it.
- New `zizmor.yml`, path-filtered to `.github/**`, results to the Security tab. Advisory by design; the hard gate stays the pin job.

## Verification

- All 7 workflows and `dependabot.yml` parse as YAML.
- 17 of 17 third-party refs on a 40-hex SHA, 1 first-party ref exempt.
- `zizmor --min-severity medium .github/` reports `No findings to report.`
- `git archive HEAD` confirmed `phpstan.neon.dist` is absent from the dist archive.

## Note on when the score moves

Plumb scores the **latest release tag**, not branch HEAD. Confirmed on packages where the two differ (`spatie/laravel-permission` is scored at tag `8.3.0` while `main` sits elsewhere). Merging alone will not move the badge; it needs a tag, then Plumb rescans on its 24h cadence.