### PR TITLE
chore(ci): watch docs dependencies, group security updates, harden workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,29 @@ updates:
       default-days: 7
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
     labels:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,6 +27,7 @@ jobs:
           echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
+        # zizmor: ignore[artipacked] git-auto-commit-action pushes the changelog with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.branch.outputs.name }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,8 +38,9 @@ jobs:
 
       - name: Set version config
         id: config
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
         run: |
-          BRANCH="${{ steps.version.outputs.branch }}"
           case $BRANCH in
             1.x)
               echo "dest_folder=." >> $GITHUB_OUTPUT
@@ -56,8 +57,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.branch }}
+          persist-credentials: false
 
       - name: Checkout gh-pages
+        # zizmor: ignore[artipacked] the deploy commit below pushes with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
@@ -84,10 +87,10 @@ jobs:
           NUXT_PUBLIC_FATHOM_SITE_ID: ${{ secrets.FATHOM_SITE_ID }}
 
       - name: Deploy to gh-pages
+        env:
+          DEST: ${{ steps.config.outputs.dest_folder }}
+          IS_LATEST: ${{ steps.config.outputs.is_latest }}
         run: |
-          DEST="${{ steps.config.outputs.dest_folder }}"
-          IS_LATEST="${{ steps.config.outputs.is_latest }}"
-
           if [ "$IS_LATEST" == "true" ]; then
             echo "Deploying latest version to root..."
             cd gh-pages
@@ -125,6 +128,8 @@ jobs:
 
       - name: Commit and push
         working-directory: ./gh-pages
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -132,6 +137,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to deploy"
           else
-            git commit -m "Deploy ${{ steps.version.outputs.branch }} docs"
+            git commit -m "Deploy $BRANCH docs"
             git push
           fi

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
+        # zizmor: ignore[artipacked] git-auto-commit-action pushes with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
 
     steps:
       - name: Checkout code
+        # zizmor: ignore[artipacked] the tag deletion below pushes with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Delete tag on test failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2


### PR DESCRIPTION
Same cleanup as relaticle/custom-fields#217, applied here.

## Docs dependencies were unmonitored

`docs/package-lock.json` exists and `deploy-docs.yml` builds from it, but `dependabot.yml` only covered `github-actions`. Added the `npm` entry for `/docs`. This is the exact gap that left relaticle/ink with 30 unseen advisories in the same file.

## Security update grouping

Each ecosystem gets a `security-updates` group alongside its version-updates group. `applies-to` defaults to version updates, so without this every advisory arrives as its own PR.

## Workflows

Clears all 10 code scanning alerts (6 `artipacked`, 4 `template-injection`). Verified with `zizmor --no-online-audits`: 10 findings before, 0 after, nothing new introduced.

- `tests.yml` and the source checkout in `deploy-docs.yml` never push, so they get `persist-credentials: false`.
- The four checkouts whose credential is deliberately used for a later push (gh-pages deploy, `pint.yml` and `changelog.yml` auto-commits, the release tag cleanup) carry an inline ignore naming the push.
- Step outputs move out of `run:` bodies into `env:`.

## Also done outside this PR

`allow_auto_merge` was off at the repo level, so `auto-merge.yml` could never merge a Dependabot PR. Now enabled.

Caveat worth deciding separately: a merge enabled with `GITHUB_TOKEN` does not trigger `on: push` workflows, and `deploy-docs.yml` is `on: push` with `paths: docs/**`. Auto-merged docs bumps would stop redeploying the docs site until that uses a GitHub App token or a scheduled redeploy.